### PR TITLE
Add host logging capability.

### DIFF
--- a/admin/src/LogsPage.ts
+++ b/admin/src/LogsPage.ts
@@ -93,6 +93,7 @@ export default function LogsPage({ setTitleSide }: PageProps) {
                             { k: CFG.log_gui, sm: 6, comp: BoolField, label: "Log interface loading", helperText: "Some requests are necessary to load the interface" },
                             { k: CFG.log_api, sm: 6, comp: BoolField, label: "Log API requests", helperText: "Requests for commands" },
                             { k: CFG.log_ua, sm: 6, comp: BoolField, label: "Log User-Agent", helperText: "Contains browser and possibly OS information. Can double the size of your logs on disk." },
+                            { k: CFG.log_host, sm: 6, comp: BoolField, label: "Log Host", helperText: "Log the host header of each request." },
                             { k: CFG.log_spam, sm: 6, comp: BoolField, label: "Log spam requests", helperText: md`Spam requests are *failed* requests that you probably don't want to see` },
                             { k: CFG.track_ips, sm: 6, comp: BoolField, label: "Keep track of IPs",
                                 parentProps: { display: 'flex', gap: 1 },
@@ -116,6 +117,7 @@ type LogFileProps = { filter?: (row:any) => boolean, limit?: number, hidden?: bo
 export function LogFile({ file, footerSide, hidden, limit, filter, ...rest }: LogFileProps) {
     const [showCountry, setShowCountry] = useState(false)
     const [showAgent, setShowAgent] = useState(false)
+    const [showHost, setShowHost] = useState(false)
     const { pause, pauseButton } = usePauseButton()
     const [showApi, showApiButton] = useToggleButton("Show APIs", "Hide APIs", v => ({
         icon: SmartToy,
@@ -302,6 +304,13 @@ export function LogFile({ file, footerSide, hidden, limit, filter, ...rest }: Lo
                 renderCell: ({ value }) => agentIcons(value),
             },
             {
+                field: 'host',
+                headerName: "Host",
+                width: 100,
+                hideUnder: !showHost || 'md',
+                valueGetter: ({ row }) => row.extra?.host,
+            },
+            {
                 field: 'notes',
                 headerName: "Notes",
                 width: 110,
@@ -345,6 +354,8 @@ export function LogFile({ file, footerSide, hidden, limit, filter, ...rest }: Lo
             setShowCountry(true)
         if (extra?.ua && !showAgent)
             setShowAgent(true)
+        if (extra?.host && !showHost)
+            setShowHost(true)
         if (row.uri) {
             const upload = row.method === 'PUT' || extra?.ul
             const partial = upload && stringAfter('?', row.uri).includes('partial=')

--- a/src/cross.ts
+++ b/src/cross.ts
@@ -30,7 +30,7 @@ export const SORT_BY_OPTIONS = ['name', 'extension', 'size', 'time', 'creation']
 export const THEME_OPTIONS = { auto: '', light: 'light', dark: 'dark' }
 // had found an interesting way to infer a type from all the calls to defineConfig (by the literals passed), but would not be usable also by admin-panel
 export const CFG = constMap(['geo_enable', 'geo_allow', 'geo_list', 'geo_allow_unknown', 'dynamic_dns_url',
-    'log', 'error_log', 'log_rotation', 'dont_log_net', 'log_gui', 'log_api', 'log_ua', 'log_spam', 'track_ips',
+    'log', 'error_log', 'log_rotation', 'dont_log_net', 'log_gui', 'log_api', 'log_ua', 'log_spam', 'log_host', 'track_ips',
     'max_downloads', 'max_downloads_per_ip', 'max_downloads_per_account', 'roots', 'force_address', 'split_uploads',
     'force_lang', 'suspend_plugins', 'base_url', 'size_1024', 'disable_custom_html', 'comments_storage',
     'force_webdav_login', 'webdav_initial_auth', 'outbound_proxy'])

--- a/src/log.ts
+++ b/src/log.ts
@@ -140,7 +140,7 @@ export const logMw: Koa.Middleware = async (ctx, next) => {
         if (logUA.get())
             ctx.logExtra({ ua: ctx.get('user-agent') || undefined })
         if (logHost.get())
-            ctx.logExtra({ domain: ctx.get('host') || undefined })
+            ctx.logExtra({ host: ctx.get('host') || undefined })
         const extra = ctx.state.logExtra
         if (events.anyListener(logger.name)) // small optimization: this event can happen often, while most times there's no listener, and the parameters object is constructed pointlessly. A benchmark measured it 20% faster (just the line), while maybe it was not necessary.
             events.emit(logger.name, { ctx, length, user, ts: reqEnd, uri, extra })

--- a/src/log.ts
+++ b/src/log.ts
@@ -68,6 +68,7 @@ const logRotation = defineConfig(CFG.log_rotation, 'weekly')
 const dontLogNet = defineConfig(CFG.dont_log_net, '127.0.0.1|::1', v => makeNetMatcher(v))
 const logUA = defineConfig(CFG.log_ua, false)
 const logSpam = defineConfig(CFG.log_spam, false)
+const logHost = defineConfig(CFG.log_host, false)
 
 const debounce = _.debounce(cb => cb(), 1000) // with this technique, i'll be able to debounce some code respecting the references in its closure
 
@@ -138,6 +139,8 @@ export const logMw: Koa.Middleware = async (ctx, next) => {
             ctx.logExtra({ country: conn.country })
         if (logUA.get())
             ctx.logExtra({ ua: ctx.get('user-agent') || undefined })
+        if (logHost.get())
+            ctx.logExtra({ domain: ctx.get('host') || undefined })
         const extra = ctx.state.logExtra
         if (events.anyListener(logger.name)) // small optimization: this event can happen often, while most times there's no listener, and the parameters object is constructed pointlessly. A benchmark measured it 20% faster (just the line), while maybe it was not necessary.
             events.emit(logger.name, { ctx, length, user, ts: reqEnd, uri, extra })


### PR DESCRIPTION
Since you can host multiple adresses, it is sensible to log the host of incoming requests in that case. This PR adds this capability.

<img width="400" height="auto" alt="grafik" src="https://github.com/user-attachments/assets/2f2c93d8-2e23-4d8b-867b-92d084512c6b" />

(default should be set to off)

<img width="600" height="auto" alt="grafik" src="https://github.com/user-attachments/assets/dfae7927-93ed-4684-bd67-8a912c83cb5d" />

(the column is hidden by default)

in `access.log:`
```
127.0.0.1 - - [12/Jun/2026:23:57:47 +0200] "POST /~/api/get_status HTTP/1.1" 200 1111 "{\"aborted\":true,\"ua\":\"Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:151.0) Gecko/20100101 Firefox/151.0\",\"host\":\"localhost\"}"
127.0.0.1 - - [12/Jun/2026:23:57:48 +0200] "POST /~/api/get_status HTTP/1.1" 200 1111 "{\"ua\":\"Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:151.0) Gecko/20100101 Firefox/151.0\",\"host\":\"localhost\"}"
```
