### PR TITLE
fix: FilePicker selection regression on Windows

### DIFF
--- a/admin/src/FilePicker.ts
+++ b/admin/src/FilePicker.ts
@@ -112,9 +112,12 @@ export default function FilePicker({ onSelect, multiple=true, files=true, folder
                         : h(FixedSizeList, {
                             width: '100%', height: listHeight,
                             itemSize: 46, itemCount: filteredList.length, overscanCount: 5,
-                            children({ index, style }) {
+                            itemData: { filteredList, sel, multiple, folders, cwdDelimiter, pathDelimiter, setCwd, onSelect, setSel },
+                            children({ index, style, data }: any) {
+                                const { filteredList, sel, multiple, folders, cwdDelimiter, pathDelimiter, setCwd, onSelect, setSel } = data
                                 const it = filteredList[index]
                                 const isFolder = it.k === 'd'
+                                const id = entrySelId(it, pathDelimiter)
                                 // mui v9 requires MenuItem under MenuList, while these virtualized rows are plain list buttons
                                 return h(ListItemButton, {
                                         style: { ...style, padding: 0 },
@@ -127,11 +130,10 @@ export default function FilePicker({ onSelect, multiple=true, files=true, folder
                                         }
                                     },
                                     multiple && h(Checkbox, {
-                                        checked: sel.includes(it.n),
+                                        checked: sel.includes(id),
                                         disabled: !folders && isFolder,
                                         onClick(ev) {
-                                            const id = it.n + (it.k ? '/' : '')
-                                            const removed = sel.filter(x => x !== id)
+                                            const removed = sel.filter((x: string) => x !== id)
                                             setSel(removed.length < sel.length ? removed : [...sel, id])
                                             ev.stopPropagation()
                                         },
@@ -179,6 +181,10 @@ export default function FilePicker({ onSelect, multiple=true, files=true, folder
                 ),
             )
     )
+}
+
+function entrySelId(it: LsEntry, pathDelimiter: string) {
+    return it.n + (it.k ? pathDelimiter : '')
 }
 
 export function formatDiskSpace({ free, total }: { free: number, total: number }) {

--- a/admin/src/addFiles.ts
+++ b/admin/src/addFiles.ts
@@ -34,9 +34,15 @@ export default function addFiles() {
     })
 }
 
+function isFolderSource(source?: string) {
+    if (!source) return false
+    const sep = getHFS().pathSeparator
+    return source.endsWith(sep) || source.endsWith(sep === '\\' ? '/' : '\\')
+}
+
 function addNodes(parent: VfsNodeAdmin, nodes: Optional<VfsNodeAdmin, 'id' | 'originalId'>[]) {
     for (const n of nodes) {
-        if (n.source?.endsWith(getHFS().pathSeparator) || !n.source && !n.url)
+        if (isFolderSource(n.source) || !n.source && !n.url)
             n.type = 'folder'
         n.id ||= parent.id + n.name + (n.type === 'folder' ? '/' : '')
         n.originalId ||= n.id


### PR DESCRIPTION
## Summary

Fixes two regressions in the admin FilePicker on Windows (introduced around `2d03f025`):

1. Folder checkbox does not show checked state
2. Disk folders are added as files in VFS

Fixes #1242, #1243

## Changes

- `FilePicker.ts`: use `pathDelimiter` consistently for selection ids; align `checked` with toggle logic; pass `itemData` so react-window re-renders checkbox state
- `addFiles.ts`: add `isFolderSource()` accepting paths ending with either `\` or `/`